### PR TITLE
ux: restructure forms and adapt signup flow with supabase fallback

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -12,7 +12,9 @@ const PROFILE_OPTIONAL_FIELDS = [
   'tagline',
   'national_id',
   'rccm',
-  'nif'
+  'nif',
+  'phone',
+  'website'
 ]
 
 const LOGO_BUCKET = process.env.SUPABASE_LOGO_BUCKET || 'company-logos'
@@ -303,7 +305,7 @@ const createProfileInternal = async ({ email, company, userId, ...rest }) => {
     .from('profiles')
     .upsert(profileRecord, { onConflict: 'id' })
     .select(
-      'company, tagline, logo_url, manager_name, address, city, state, national_id, rccm, nif'
+      'company, tagline, logo_url, manager_name, address, city, state, national_id, rccm, nif, phone, website'
     )
     .single()
 
@@ -361,7 +363,7 @@ export const createProfile = async (req, res, next) => {
     const { data, error } = await supabase
       .from('profiles')
       .select(
-        'company, tagline, logo_url, manager_name, address, city, state, national_id, rccm, nif'
+        'company, tagline, logo_url, manager_name, address, city, state, national_id, rccm, nif, phone, website'
       )
       .eq('id', userId)
       .single()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@supabase/supabase-js": "^2.45.2",
 				"axios": "^1.7.7",
+				"clsx": "^2.1.1",
 				"lucide-react": "^0.447.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -2026,6 +2027,15 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/color-convert": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@supabase/supabase-js": "^2.45.2",
 		"axios": "^1.7.7",
+		"clsx": "^2.1.1",
 		"lucide-react": "^0.447.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/frontend/src/components/FormSection.jsx
+++ b/frontend/src/components/FormSection.jsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx'
+
+const baseCard = 'rounded-[var(--radius-xl)] border border-[var(--border)] bg-white/85 p-6 shadow-soft'
+
+const FormSection = ({ title, description, icon: Icon, children, className }) => (
+  <section className={clsx(baseCard, 'space-y-4', className)}>
+    {(title || description || Icon) && (
+      <header className='flex items-start gap-3'>
+        {Icon ? (
+          <span className='inline-flex h-10 w-10 items-center justify-center rounded-full bg-[var(--primary-soft)] text-[var(--primary)] shadow-soft'>
+            <Icon className='h-4 w-4' />
+          </span>
+        ) : null}
+        <div>
+          {title ? <h2 className='text-base font-semibold text-[var(--text-dark)]'>{title}</h2> : null}
+          {description ? <p className='text-sm text-[var(--text-muted)]'>{description}</p> : null}
+        </div>
+      </header>
+    )}
+    <div className='space-y-3'>{children}</div>
+  </section>
+)
+
+export default FormSection

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -16,7 +16,9 @@ const emptyProfile = {
   state: '',
   national_id: '',
   rccm: '',
-  nif: ''
+  nif: '',
+  phone: '',
+  website: ''
 }
 
 const OPTIONAL_PROFILE_FIELDS = [
@@ -28,7 +30,9 @@ const OPTIONAL_PROFILE_FIELDS = [
   'tagline',
   'national_id',
   'rccm',
-  'nif'
+  'nif',
+  'phone',
+  'website'
 ]
 
 const deriveFallbackProfile = (user) => {
@@ -61,7 +65,9 @@ export const AuthProvider = ({ children }) => {
         state: data?.state ?? '',
         national_id: data?.national_id ?? '',
         rccm: data?.rccm ?? '',
-        nif: data?.nif ?? ''
+        nif: data?.nif ?? '',
+        phone: data?.phone ?? '',
+        website: data?.website ?? ''
       })
     } catch (error) {
       console.warn('Impossible de récupérer le profil:', error.message)
@@ -192,7 +198,9 @@ export const AuthProvider = ({ children }) => {
           national_id:
             data.national_id ?? sanitizedPayload.national_id ?? fallback.national_id ?? '',
           rccm: data.rccm ?? sanitizedPayload.rccm ?? fallback.rccm ?? '',
-          nif: data.nif ?? sanitizedPayload.nif ?? fallback.nif ?? ''
+          nif: data.nif ?? sanitizedPayload.nif ?? fallback.nif ?? '',
+          phone: data.phone ?? sanitizedPayload.phone ?? fallback.phone ?? '',
+          website: data.website ?? sanitizedPayload.website ?? fallback.website ?? ''
         }
       })
     },

--- a/frontend/src/pages/Catalogue.jsx
+++ b/frontend/src/pages/Catalogue.jsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { createCatalogItem, fetchCatalogItems, updateCatalogItem } from '../services/catalog.js'
 import { showErrorToast } from '../utils/errorToast.js'
+import FormSection from '../components/FormSection.jsx'
 
 const emptyForm = {
   name: '',
@@ -141,6 +142,111 @@ const Catalogue = () => {
   const handleFilterChange = (type) => {
     setFilters((prev) => ({ ...prev, type }))
   }
+
+  const renderCatalogueFormSections = () => (
+    <div className='space-y-4'>
+      <FormSection
+        title='Informations générales'
+        description='Nom, description et nature de votre prestation.'
+        icon={Package}
+      >
+        <div className='flex flex-col gap-2'>
+          <label className='label' htmlFor='name'>Nom de l’article</label>
+          <input
+            id='name'
+            value={form.name}
+            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+            className='input-compact'
+            placeholder='Nom du produit ou service'
+            required
+          />
+        </div>
+        <div className='flex flex-col gap-2'>
+          <label className='label' htmlFor='description'>Description</label>
+          <textarea
+            id='description'
+            value={form.description}
+            onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+            className='textarea textarea-compact min-h-[110px]'
+            placeholder='Détaillez en quoi consiste cet article…'
+          />
+        </div>
+        <div className='grid gap-3 sm:grid-cols-2'>
+          <div className='space-y-2'>
+            <label className='label'>Type</label>
+            <div className='grid grid-cols-2 gap-2'>
+              <button
+                type='button'
+                onClick={() => setForm((prev) => ({ ...prev, item_type: 'product' }))}
+                className={`btn-ghost h-9 justify-center text-xs font-semibold ${
+                  form.item_type === 'product' ? 'border-[var(--primary)] text-[var(--primary)]' : ''
+                }`}
+              >
+                <Package className='mr-2 h-4 w-4' /> Produit
+              </button>
+              <button
+                type='button'
+                onClick={() => setForm((prev) => ({ ...prev, item_type: 'service' }))}
+                className={`btn-ghost h-9 justify-center text-xs font-semibold ${
+                  form.item_type === 'service' ? 'border-[var(--primary)] text-[var(--primary)]' : ''
+                }`}
+              >
+                <Wand2 className='mr-2 h-4 w-4' /> Service
+              </button>
+            </div>
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='label' htmlFor='sku'>Référence interne (SKU)</label>
+            <input
+              id='sku'
+              value={form.sku}
+              onChange={(event) => setForm((prev) => ({ ...prev, sku: event.target.value }))}
+              className='input-compact'
+              placeholder='Ex. PROD-001'
+            />
+          </div>
+        </div>
+      </FormSection>
+
+      <FormSection
+        title='Tarification'
+        description='Déterminez le prix par défaut et la devise.'
+        icon={BadgeCheck}
+      >
+        <div className='grid gap-3 sm:grid-cols-2'>
+          <div className='flex flex-col gap-2'>
+            <label className='label' htmlFor='unit_price'>Prix unitaire</label>
+            <input
+              id='unit_price'
+              type='number'
+              min='0'
+              step='0.01'
+              value={form.unit_price}
+              onChange={(event) => setForm((prev) => ({ ...prev, unit_price: event.target.value }))}
+              className='input-compact'
+              placeholder='0.00'
+            />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='label' htmlFor='currency'>Devise</label>
+            <input
+              id='currency'
+              value={form.currency}
+              onChange={(event) =>
+                setForm((prev) => ({
+                  ...prev,
+                  currency: event.target.value.toUpperCase().slice(0, 3)
+                }))
+              }
+              className='input-compact uppercase'
+              placeholder='USD'
+              maxLength={3}
+            />
+          </div>
+        </div>
+      </FormSection>
+    </div>
+  )
 
   return (
     <div className='space-y-8'>
@@ -371,119 +477,8 @@ const Catalogue = () => {
             </div>
             <form onSubmit={handleCreate} className='flex h-full flex-col'>
               <div className='flex-1 space-y-4 overflow-y-auto px-6 py-6'>
-                <div className='space-y-2'>
-                  <label className='label' htmlFor='name'>
-                    Intitulé
-                  </label>
-                  <input
-                    id='name'
-                    value={form.name}
-                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-                    className='input-compact'
-                    placeholder='Nom du produit ou service'
-                    required
-                  />
-                </div>
-
-                <div className='space-y-2'>
-                  <label className='label' htmlFor='description'>
-                    Description
-                  </label>
-                  <textarea
-                    id='description'
-                    value={form.description}
-                    onChange={(event) =>
-                      setForm((prev) => ({ ...prev, description: event.target.value }))
-                    }
-                    className='textarea textarea-compact min-h-[110px]'
-                    placeholder='Détaillez en quoi consiste cet article…'
-                  />
-                </div>
-
-                <div className='grid gap-3 sm:grid-cols-2'>
-                  <div className='space-y-2'>
-                    <label className='label'>Type</label>
-                    <div className='grid grid-cols-2 gap-2'>
-                      <button
-                        type='button'
-                        onClick={() => setForm((prev) => ({ ...prev, item_type: 'product' }))}
-                        className={`btn-ghost h-9 justify-center text-xs font-semibold ${
-                          form.item_type === 'product'
-                            ? 'border-[var(--primary)] text-[var(--primary)]'
-                            : ''
-                        }`}
-                      >
-                        <Package className='mr-2 h-4 w-4' />
-                        Produit
-                      </button>
-                      <button
-                        type='button'
-                        onClick={() => setForm((prev) => ({ ...prev, item_type: 'service' }))}
-                        className={`btn-ghost h-9 justify-center text-xs font-semibold ${
-                          form.item_type === 'service'
-                            ? 'border-[var(--primary)] text-[var(--primary)]'
-                            : ''
-                        }`}
-                      >
-                        <Wand2 className='mr-2 h-4 w-4' />
-                        Service
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className='space-y-2'>
-                    <label className='label' htmlFor='sku'>
-                      Référence interne (SKU)
-                    </label>
-                    <input
-                      id='sku'
-                      value={form.sku}
-                      onChange={(event) => setForm((prev) => ({ ...prev, sku: event.target.value }))}
-                      className='input-compact'
-                      placeholder='Ex. PROD-001'
-                    />
-                  </div>
-                </div>
-
-                <div className='grid gap-3 sm:grid-cols-2'>
-                  <div className='space-y-2'>
-                    <label className='label' htmlFor='unit_price'>
-                      Prix unitaire
-                    </label>
-                    <input
-                      id='unit_price'
-                      type='number'
-                      min='0'
-                      step='0.01'
-                      value={form.unit_price}
-                      onChange={(event) =>
-                        setForm((prev) => ({ ...prev, unit_price: event.target.value }))
-                      }
-                      className='input-compact'
-                      placeholder='0.00'
-                    />
-                  </div>
-                  <div className='space-y-2'>
-                    <label className='label' htmlFor='currency'>
-                      Devise
-                    </label>
-                    <input
-                      id='currency'
-                      value={form.currency}
-                      onChange={(event) =>
-                        setForm((prev) => ({
-                          ...prev,
-                          currency: event.target.value.toUpperCase().slice(0, 3)
-                        }))
-                      }
-                      className='input-compact uppercase'
-                      placeholder='USD'
-                      maxLength={3}
-                    />
-                  </div>
-                </div>
+                {renderCatalogueFormSections()}
               </div>
-
               <div className='flex items-center justify-between gap-2 border-t border-[var(--border)] px-6 py-4'>
                 <button
                   type='button'

--- a/frontend/src/pages/Clients.jsx
+++ b/frontend/src/pages/Clients.jsx
@@ -17,6 +17,7 @@ import {
   PlusCircle
 } from 'lucide-react'
 import { api } from '../services/api.js'
+import FormSection from '../components/FormSection.jsx'
 import { showErrorToast } from '../utils/errorToast.js'
 
 const initialState = {
@@ -157,6 +158,78 @@ const Clients = () => {
       setIsDrawerOpen(false)
     }
   }
+
+  const buildFormSections = (values, onChangeHandler) => (
+    <div className='space-y-4'>
+      <FormSection
+        title='Identité client'
+        description="Nom de l'entreprise et personne de contact."
+        icon={Building2}
+      >
+        <div className='flex flex-col gap-2'>
+          <label className='label'>Entreprise</label>
+          <input
+            name='company_name'
+            value={values.company_name}
+            onChange={onChangeHandler}
+            placeholder='Ex. Alpha SARL'
+            className='input'
+            required
+          />
+        </div>
+        <div className='flex flex-col gap-2'>
+          <label className='label'>Contact principal</label>
+          <input
+            name='contact_name'
+            value={values.contact_name}
+            onChange={onChangeHandler}
+            placeholder='Nom & prénom'
+            className='input'
+          />
+        </div>
+      </FormSection>
+
+      <FormSection
+        title='Coordonnées'
+        description='Moyens de communication privilégiés.'
+        icon={Mail}
+      >
+        <div className='grid gap-4 sm:grid-cols-2'>
+          <div className='flex flex-col gap-2'>
+            <label className='label'>Email</label>
+            <input
+              type='email'
+              name='email'
+              value={values.email}
+              onChange={onChangeHandler}
+              placeholder='client@entreprise.com'
+              className='input'
+            />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='label'>Téléphone</label>
+            <input
+              name='phone'
+              value={values.phone}
+              onChange={onChangeHandler}
+              placeholder='+243 000 000 000'
+              className='input'
+            />
+          </div>
+        </div>
+      </FormSection>
+
+      <FormSection title='Adresse (optionnel)' icon={MapPin}>
+        <textarea
+          name='address'
+          value={values.address}
+          onChange={onChangeHandler}
+          placeholder="Adresse postale du client"
+          className='textarea textarea-compact min-h-[90px]'
+        />
+      </FormSection>
+    </div>
+  )
 
   return (
     <div className='space-y-8'>
@@ -316,75 +389,7 @@ const Clients = () => {
 
             <form onSubmit={handleSubmit} className='flex h-full flex-col'>
               <div className='flex-1 space-y-4 overflow-y-auto px-6 py-6'>
-                <div className='space-y-2'>
-                  <label className='label flex items-center gap-2'>
-                    <Building2 className='h-4 w-4 text-[var(--text-muted)]' />
-                    Raison sociale
-                  </label>
-                  <input
-                    name='company_name'
-                    value={form.company_name}
-                    onChange={handleChange}
-                    className='input-compact'
-                    placeholder='Nom de l’entreprise'
-                    required
-                  />
-                </div>
-                <div className='space-y-2'>
-                  <label className='label flex items-center gap-2'>
-                    <IdCard className='h-4 w-4 text-[var(--text-muted)]' />
-                    Contact principal
-                  </label>
-                  <input
-                    name='contact_name'
-                    value={form.contact_name}
-                    onChange={handleChange}
-                    className='input-compact'
-                    placeholder='Nom et prénom'
-                  />
-                </div>
-                <div className='grid gap-3 sm:grid-cols-2'>
-                  <div className='space-y-2'>
-                    <label className='label flex items-center gap-2'>
-                      <Mail className='h-4 w-4 text-[var(--text-muted)]' />
-                      Email
-                    </label>
-                    <input
-                      type='email'
-                      name='email'
-                      value={form.email}
-                      onChange={handleChange}
-                      className='input-compact'
-                      placeholder='exemple@entreprise.com'
-                    />
-                  </div>
-                  <div className='space-y-2'>
-                    <label className='label flex items-center gap-2'>
-                      <Phone className='h-4 w-4 text-[var(--text-muted)]' />
-                      Téléphone
-                    </label>
-                    <input
-                      name='phone'
-                      value={form.phone}
-                      onChange={handleChange}
-                      className='input-compact'
-                      placeholder='+243 000 000'
-                    />
-                  </div>
-                </div>
-                <div className='space-y-2'>
-                  <label className='label flex items-center gap-2'>
-                    <MapPin className='h-4 w-4 text-[var(--text-muted)]' />
-                    Adresse complète
-                  </label>
-                  <textarea
-                    name='address'
-                    value={form.address}
-                    onChange={handleChange}
-                    className='textarea textarea-compact min-h-[110px]'
-                    placeholder='Adresse postale, ville, pays…'
-                  />
-                </div>
+                {buildFormSections(form, handleChange)}
               </div>
               <div className='flex items-center justify-between gap-2 border-t border-[var(--border)] px-6 py-4'>
                 <button
@@ -433,70 +438,7 @@ const Clients = () => {
             </div>
 
             <form onSubmit={handleUpdateClient} className='space-y-4'>
-              <div className='space-y-2'>
-                <label className='label flex items-center gap-2'>
-                  <Building2 className='h-4 w-4 text-[var(--text-muted)]' />
-                  Raison sociale
-                </label>
-                <input
-                  name='company_name'
-                  value={editingClient.company_name}
-                  onChange={handleEditChange}
-                  className='input'
-                  required
-                />
-              </div>
-              <div className='space-y-2'>
-                <label className='label flex items-center gap-2'>
-                  <IdCard className='h-4 w-4 text-[var(--text-muted)]' />
-                  Contact principal
-                </label>
-                <input
-                  name='contact_name'
-                  value={editingClient.contact_name}
-                  onChange={handleEditChange}
-                  className='input'
-                />
-              </div>
-              <div className='grid gap-4 md:grid-cols-2'>
-                <div className='space-y-2'>
-                  <label className='label flex items-center gap-2'>
-                    <Mail className='h-4 w-4 text-[var(--text-muted)]' />
-                    Email
-                  </label>
-                  <input
-                    type='email'
-                    name='email'
-                    value={editingClient.email}
-                    onChange={handleEditChange}
-                    className='input'
-                  />
-                </div>
-                <div className='space-y-2'>
-                  <label className='label flex items-center gap-2'>
-                    <Phone className='h-4 w-4 text-[var(--text-muted)]' />
-                    Téléphone
-                  </label>
-                  <input
-                    name='phone'
-                    value={editingClient.phone}
-                    onChange={handleEditChange}
-                    className='input'
-                  />
-                </div>
-              </div>
-              <div className='space-y-2'>
-                <label className='label flex items-center gap-2'>
-                  <MapPin className='h-4 w-4 text-[var(--text-muted)]' />
-                  Adresse complète
-                </label>
-                <textarea
-                  name='address'
-                  value={editingClient.address}
-                  onChange={handleEditChange}
-                  className='textarea min-h-[120px]'
-                />
-              </div>
+              {buildFormSections(editingClient, handleEditChange)}
 
               <div className='flex justify-end gap-2 pt-2'>
                 <button type='button' onClick={closeEditClient} className='btn-ghost px-4 text-sm font-semibold'>

--- a/frontend/src/pages/Company.jsx
+++ b/frontend/src/pages/Company.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
-import { Building2, Image as ImageIcon } from 'lucide-react'
+import { Building2, Image as ImageIcon, Link as LinkIcon, Phone } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth.jsx'
 import { uploadCompanyLogo } from '../services/supabase.js'
 import { showErrorToast } from '../utils/errorToast.js'
+import FormSection from '../components/FormSection.jsx'
 
 const initialState = {
   company: '',
@@ -14,7 +15,9 @@ const initialState = {
   tagline: '',
   national_id: '',
   rccm: '',
-  nif: ''
+  nif: '',
+  phone: '',
+  website: ''
 }
 
 const trimOrNull = (value) => {
@@ -45,7 +48,9 @@ const Company = () => {
       tagline: data.tagline ?? '',
       national_id: data.national_id ?? '',
       rccm: data.rccm ?? '',
-      nif: data.nif ?? ''
+      nif: data.nif ?? '',
+      phone: data.phone ?? '',
+      website: data.website ?? ''
     })
     setLogoPreview(data.logo_url ?? '')
     setLogoFile(null)
@@ -110,7 +115,9 @@ const Company = () => {
         tagline: trimOrNull(form.tagline),
         national_id: trimOrNull(form.national_id),
         rccm: trimOrNull(form.rccm),
-        nif: trimOrNull(form.nif)
+        nif: trimOrNull(form.nif),
+        phone: trimOrNull(form.phone),
+        website: trimOrNull(form.website)
       }
 
       if (!payload.company) {
@@ -149,6 +156,41 @@ const Company = () => {
 
   const disabled = isLoading || isSaving || isUploadingLogo
 
+  const renderLogoUploader = () => (
+    <div className='flex flex-col items-center gap-3 rounded-[var(--radius-xl)] border border-dashed border-[var(--border)] bg-[rgba(15,23,42,0.02)] p-5 text-center'>
+      <div className='relative flex h-28 w-28 items-center justify-center rounded-[var(--radius-lg)] bg-white shadow-soft'>
+        {logoPreview ? (
+          <img
+            src={logoPreview}
+            alt='Logo de votre entreprise'
+            className='h-full w-full rounded-[var(--radius-lg)] object-contain'
+          />
+        ) : (
+          <div className='flex h-full w-full flex-col items-center justify-center gap-2 text-[var(--text-muted)]'>
+            <ImageIcon className='h-8 w-8' />
+            <span className='text-xs font-semibold'>Logo</span>
+          </div>
+        )}
+        <label className='btn-primary absolute -bottom-3 left-1/2 flex h-9 -translate-x-1/2 items-center justify-center px-4 text-xs font-semibold shadow-soft'>
+          {logoPreview ? 'Modifier' : 'Importer un logo'}
+          <input type='file' accept='image/*' className='hidden' onChange={handleLogoChange} disabled={disabled} />
+        </label>
+      </div>
+      {logoPreview ? (
+        <button
+          type='button'
+          className='text-xs font-semibold text-[var(--text-muted)] hover:text-[var(--text-dark)]'
+          onClick={handleLogoReset}
+          disabled={disabled}
+        >
+          Réinitialiser
+        </button>
+      ) : null}
+      {logoError ? <p className='text-xs text-red-500'>{logoError}</p> : null}
+      <p className='text-[11px] text-[var(--text-muted)]'>PNG ou JPG · 1&nbsp;Mo max.</p>
+    </div>
+  )
+
   return (
     <div className='space-y-8'>
       <header className='flex flex-col gap-2'>
@@ -157,162 +199,152 @@ const Company = () => {
         <p className='text-sm text-[var(--text-muted)]'>Ces informations apparaîtront sur vos factures et dans la navigation.</p>
       </header>
 
-      <div className='card border border-white/60 p-0 shadow-[0_18px_52px_-44px_rgba(28,28,30,0.22)]'>
-        <div className='flex items-center gap-3 border-b border-[var(--border)] bg-[rgba(255,255,255,0.75)] px-6 py-4'>
-          <div className='rounded-full bg-[var(--primary-soft)] p-2 text-[var(--primary)] shadow-soft'>
-            <Building2 className='h-5 w-5' />
+      <form onSubmit={handleSubmit} className='space-y-6'>
+        <FormSection
+          title="Identité visuelle"
+          description='Votre logo et votre slogan apparaîtront sur vos factures.'
+          icon={ImageIcon}
+        >
+          {renderLogoUploader()}
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Nom de l’entreprise</label>
+              <input name='company' value={form.company} onChange={handleChange} className='input' required />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Tagline (optionnel)</label>
+              <input
+                name='tagline'
+                value={form.tagline}
+                onChange={handleChange}
+                className='input'
+                placeholder='Facturation simple pour PME'
+              />
+            </div>
           </div>
-          <div>
-            <h2 className='text-lg font-semibold text-[var(--text-dark)]'>Coordonnées principales</h2>
-            <p className='text-xs text-[var(--text-muted)]'>Complétez les champs nécessaires à l’édition de vos documents.</p>
+        </FormSection>
+
+        <FormSection
+          title='Coordonnées principales'
+          description="Ces informations sont utilisées pour contacter votre entreprise."
+          icon={Phone}
+        >
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Responsable</label>
+              <input
+                name='manager_name'
+                value={form.manager_name}
+                onChange={handleChange}
+                className='input'
+                placeholder='Nom et prénom'
+              />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Téléphone</label>
+              <input
+                name='phone'
+                value={form.phone}
+                onChange={handleChange}
+                className='input'
+                placeholder='+243 000 000 000'
+              />
+            </div>
           </div>
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Email de contact</label>
+              <input value={companyEmail} disabled className='input bg-[rgba(148,163,184,0.12)]' />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Site web (optionnel)</label>
+              <input
+                name='website'
+                value={form.website}
+                onChange={handleChange}
+                className='input'
+                placeholder='https://kadi.app'
+              />
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection
+          title='Adresse professionnelle'
+          description='Ces informations apparaissent sur vos factures et documents légaux.'
+          icon={Building2}
+        >
+          <div className='flex flex-col gap-2'>
+            <label className='label'>Adresse complète</label>
+            <textarea
+              name='address'
+              value={form.address}
+              onChange={handleChange}
+              className='textarea textarea-compact min-h-[100px]'
+              placeholder='Adresse postale, quartier, numéro de bâtiment…'
+            />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Ville</label>
+              <input name='city' value={form.city} onChange={handleChange} className='input' />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>État / Province</label>
+              <input name='state' value={form.state} onChange={handleChange} className='input' />
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title='Mentions légales (optionnel)' icon={LinkIcon}>
+          <div className='grid gap-4 md:grid-cols-3'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>ID. Nat.</label>
+              <input
+                name='national_id'
+                value={form.national_id}
+                onChange={handleChange}
+                className='input'
+                placeholder='Numéro national'
+              />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>RCCM</label>
+              <input
+                name='rccm'
+                value={form.rccm}
+                onChange={handleChange}
+                className='input'
+                placeholder='RCCM'
+              />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>NIF</label>
+              <input
+                name='nif'
+                value={form.nif}
+                onChange={handleChange}
+                className='input'
+                placeholder='Numéro fiscal'
+              />
+            </div>
+          </div>
+        </FormSection>
+
+        <div className='flex justify-end gap-3 pt-2'>
+          <button
+            type='button'
+            onClick={() => syncFormWithProfile(profile)}
+            className='btn-ghost px-4 text-sm font-semibold'
+            disabled={disabled}
+          >
+            Réinitialiser
+          </button>
+          <button type='submit' className='btn-primary px-6 text-sm font-semibold' disabled={disabled}>
+            {isSaving ? 'Enregistrement…' : 'Enregistrer'}
+          </button>
         </div>
-
-        <form onSubmit={handleSubmit} className='space-y-6 px-6 py-6'>
-          <div className='grid gap-4 md:grid-cols-[220px,1fr]'>
-            <div className='flex flex-col items-center gap-3 rounded-[var(--radius-lg)] border border-[var(--border)] bg-[rgba(255,255,255,0.75)] p-4 text-center'>
-              {logoPreview ? (
-                <img
-                  src={logoPreview}
-                  alt='Logo de votre entreprise'
-                  className='h-28 w-28 rounded-[var(--radius-md)] object-contain shadow-soft'
-                />
-              ) : (
-                <div className='flex h-28 w-28 items-center justify-center rounded-[var(--radius-md)] border border-dashed border-[var(--border)] bg-[rgba(15,23,42,0.02)] text-[var(--text-muted)]'>
-                  <ImageIcon className='h-8 w-8' />
-                </div>
-              )}
-              <label className='btn-ghost h-9 cursor-pointer px-4 text-xs font-semibold'>
-                Importer un logo
-                <input type='file' accept='image/*' className='hidden' onChange={handleLogoChange} />
-              </label>
-              {logoPreview && (
-                <button
-                  type='button'
-                  className='text-xs font-semibold text-[var(--text-muted)] hover:text-[var(--text-dark)]'
-                  onClick={handleLogoReset}
-                  disabled={disabled}
-                >
-                  Réinitialiser le logo
-                </button>
-              )}
-              {logoError ? <p className='text-xs text-red-500'>{logoError}</p> : null}
-              <p className='text-[11px] text-[var(--text-muted)]'>PNG ou JPG · 1&nbsp;Mo max.</p>
-            </div>
-
-            <div className='space-y-6'>
-              <div className='grid gap-4 md:grid-cols-2'>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>Nom de l’entreprise</label>
-                  <input
-                    name='company'
-                    value={form.company}
-                    onChange={handleChange}
-                    className='input'
-                    required
-                  />
-                </div>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>Responsable</label>
-                  <input
-                    name='manager_name'
-                    value={form.manager_name}
-                    onChange={handleChange}
-                    className='input'
-                    placeholder='Nom et prénom'
-                  />
-                </div>
-              </div>
-
-              <div className='grid gap-4 md:grid-cols-2'>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>Tagline (optionnel)</label>
-                  <input
-                    name='tagline'
-                    value={form.tagline}
-                    onChange={handleChange}
-                    className='input'
-                    placeholder='Facturation simple pour PME'
-                  />
-                </div>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>Email de contact</label>
-                  <input value={companyEmail} disabled className='input bg-[rgba(148,163,184,0.12)]' />
-                </div>
-              </div>
-
-              <div className='flex flex-col gap-2'>
-                <label className='label'>Adresse complète</label>
-                <textarea
-                  name='address'
-                  value={form.address}
-                  onChange={handleChange}
-                  className='textarea textarea-compact min-h-[100px]'
-                  placeholder='Adresse postale, quartier, numéro de bâtiment…'
-                />
-              </div>
-
-              <div className='grid gap-4 md:grid-cols-2'>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>Ville</label>
-                  <input name='city' value={form.city} onChange={handleChange} className='input' />
-                </div>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>État / Province</label>
-                  <input name='state' value={form.state} onChange={handleChange} className='input' />
-                </div>
-              </div>
-
-              <div className='grid gap-4 md:grid-cols-3'>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>ID. Nat. (optionnel)</label>
-                  <input
-                    name='national_id'
-                    value={form.national_id}
-                    onChange={handleChange}
-                    className='input'
-                    placeholder='Numéro national'
-                  />
-                </div>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>RCCM (optionnel)</label>
-                  <input
-                    name='rccm'
-                    value={form.rccm}
-                    onChange={handleChange}
-                    className='input'
-                    placeholder='RCCM'
-                  />
-                </div>
-                <div className='flex flex-col gap-2'>
-                  <label className='label'>NIF (optionnel)</label>
-                  <input
-                    name='nif'
-                    value={form.nif}
-                    onChange={handleChange}
-                    className='input'
-                    placeholder='Numéro fiscal'
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className='flex justify-end gap-3 pt-2'>
-            <button
-              type='button'
-              onClick={() => syncFormWithProfile(profile)}
-              className='btn-ghost px-4 text-sm font-semibold'
-              disabled={disabled}
-            >
-              Réinitialiser
-            </button>
-            <button type='submit' className='btn-primary px-6 text-sm font-semibold' disabled={disabled}>
-              {disabled ? 'Enregistrement…' : 'Enregistrer'}
-            </button>
-          </div>
-        </form>
-      </div>
+      </form>
     </div>
   )
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -16,11 +16,20 @@ import {
 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth.jsx'
 import { showErrorToast } from '../utils/errorToast.js'
+import FormSection from '../components/FormSection.jsx'
 
 const ACCOUNT_INITIAL = {
   email: '',
   password: '',
   confirmPassword: ''
+}
+
+const Steps = {
+  LOGIN: 'login',
+  ACCOUNT: 'register-account',
+  COMPANY_PROFILE: 'register-company-profile',
+  COMPANY_DETAILS: 'register-company-details',
+  SUCCESS: 'register-success'
 }
 
 const COMPANY_INITIAL = {
@@ -32,15 +41,16 @@ const COMPANY_INITIAL = {
   tagline: '',
   national_id: '',
   rccm: '',
-  nif: ''
+  nif: '',
+  phone: '',
+  website: ''
 }
 
-const Steps = {
-  LOGIN: 'login',
-  ACCOUNT: 'register-account',
-  COMPANY: 'register-company',
-  SUCCESS: 'register-success'
-}
+const REGISTRATION_STEPS = [
+  { id: Steps.ACCOUNT, label: 'Compte' },
+  { id: Steps.COMPANY_PROFILE, label: 'Entreprise' },
+  { id: Steps.COMPANY_DETAILS, label: 'Mentions' }
+]
 
 const MAX_LOGO_SIZE_BYTES = 1024 * 1024 // 1 MB
 
@@ -126,48 +136,35 @@ const fileToDataUrl = (file) =>
     reader.readAsDataURL(file)
   })
 
-const RegistrationStepper = ({ currentStep }) => {
-  const steps = [
-    { id: Steps.ACCOUNT, label: 'Compte' },
-    { id: Steps.COMPANY, label: 'Entreprise' }
-  ]
-
-  return (
-    <div className='mb-6 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--text-muted)]'>
-      {steps.map((step, index) => {
-        const isActive = currentStep === step.id
-        const isCompleted =
-          steps.findIndex((entry) => entry.id === currentStep) > index
-        return (
-          <div key={step.id} className='flex items-center gap-2'>
-            <div
-              className={[
-                'flex h-8 w-8 items-center justify-center rounded-full border text-[11px]',
-                isCompleted
-                  ? 'border-[var(--primary)] bg-[var(--primary-soft)] text-[var(--primary)]'
-                  : isActive
-                    ? 'border-[var(--primary)] text-[var(--primary)]'
-                    : 'border-[var(--border)] text-[var(--text-muted)]'
-              ].join(' ')}
-            >
-              {index + 1}
-            </div>
-            <span
-              className={
-                isActive || isCompleted ? 'text-[var(--text-dark)]' : undefined
-              }
-            >
-              {step.label}
-            </span>
-            {index < steps.length - 1 ? (
-              <div className='h-[1px] w-10 bg-[var(--border)]' />
-            ) : null}
+const RegistrationStepper = ({ currentStep, steps }) => (
+  <div className='mb-6 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--text-muted)]'>
+    {steps.map((step, index) => {
+      const isActive = currentStep === step.id
+      const activeIndex = steps.findIndex((entry) => entry.id === currentStep)
+      const isCompleted = activeIndex > index
+      return (
+        <div key={step.id} className='flex items-center gap-2'>
+          <div
+            className={[
+              'flex h-8 w-8 items-center justify-center rounded-full border text-[11px]',
+              isCompleted
+                ? 'border-[var(--primary)] bg-[var(--primary-soft)] text-[var(--primary)]'
+                : isActive
+                  ? 'border-[var(--primary)] text-[var(--primary)]'
+                  : 'border-[var(--border)] text-[var(--text-muted)]'
+            ].join(' ')}
+          >
+            {index + 1}
           </div>
-        )
-      })}
-    </div>
-  )
-}
+          <span className={isActive || isCompleted ? 'text-[var(--text-dark)]' : undefined}>
+            {step.label}
+          </span>
+          {index < steps.length - 1 ? <div className='h-[1px] w-10 bg-[var(--border)]' /> : null}
+        </div>
+      )
+    })}
+  </div>
+)
 
 const Login = () => {
   const { login, signup, session } = useAuth()
@@ -312,7 +309,24 @@ const Login = () => {
     }
 
     setAccountForm((prev) => ({ ...prev, email: trimmedEmail }))
-    setView(Steps.COMPANY)
+    setView(Steps.COMPANY_PROFILE)
+  }
+
+  const handleCompanyProfileSubmit = (event) => {
+    event.preventDefault()
+    const trimmedCompany = companyForm.company.trim()
+    if (!trimmedCompany) {
+      toast.error("Indiquez le nom de votre entreprise.", { icon: '⚠️' })
+      return
+    }
+
+    setCompanyForm((prev) => ({
+      ...prev,
+      company: trimmedCompany,
+      phone: prev.phone.trim(),
+      website: prev.website.trim()
+    }))
+    setView(Steps.COMPANY_DETAILS)
   }
 
   const handleLogoSelection = (file) => {
@@ -381,7 +395,9 @@ const Login = () => {
         tagline: trimOrNull(companyForm.tagline),
         national_id: trimOrNull(companyForm.national_id),
         rccm: trimOrNull(companyForm.rccm),
-        nif: trimOrNull(companyForm.nif)
+        nif: trimOrNull(companyForm.nif),
+        phone: trimOrNull(companyForm.phone),
+        website: trimOrNull(companyForm.website)
       }
 
       if (logoFile) {
@@ -538,9 +554,9 @@ const Login = () => {
 
   const renderAccountStep = () => (
     <>
-      <RegistrationStepper currentStep={Steps.ACCOUNT} />
+      <RegistrationStepper currentStep={Steps.ACCOUNT} steps={REGISTRATION_STEPS} />
       <div className='mb-6 space-y-2'>
-        <p className='text-xs uppercase tracking-[0.25em] text-[var(--text-muted)]'>Étape 1/2</p>
+        <p className='text-xs uppercase tracking-[0.25em] text-[var(--text-muted)]'>Étape 1/3</p>
         <h1 className='text-2xl font-semibold text-[var(--text-dark)]'>Créons votre accès</h1>
         <p className='text-sm text-[var(--text-muted)]'>
           Votre email servira d’identifiant. Choisissez un mot de passe robuste pour sécuriser vos factures.
@@ -668,47 +684,34 @@ const Login = () => {
     </div>
   )
 
-  const renderCompanyStep = () => (
+  const renderCompanyProfileStep = () => (
     <>
-      <RegistrationStepper currentStep={Steps.COMPANY} />
+      <RegistrationStepper currentStep={Steps.COMPANY_PROFILE} steps={REGISTRATION_STEPS} />
       <div className='mb-6 space-y-2'>
-        <p className='text-xs uppercase tracking-[0.25em] text-[var(--text-muted)]'>Étape 2/2</p>
-        <h1 className='text-2xl font-semibold text-[var(--text-dark)]'>Votre identité entreprise</h1>
+        <p className='text-xs uppercase tracking-[0.25em] text-[var(--text-muted)]'>Étape 2/3</p>
+        <h1 className='text-2xl font-semibold text-[var(--text-dark)]'>Profil de votre entreprise</h1>
         <p className='text-sm text-[var(--text-muted)]'>
-          Ces informations alimentent vos factures et votre future zone client. Vous pourrez les compléter plus tard.
+          Ajoutez les informations visibles par vos clients (nom, slogan, contacts, logo).
         </p>
       </div>
 
-      <form
-        onSubmit={handleRegistrationSubmit}
-        className='space-y-5 rounded-[var(--radius-xl)] border border-[var(--border)] bg-white/85 p-6 shadow-soft'
-      >
-        <div className='rounded-[var(--radius-xl)] bg-[rgba(15,23,42,0.02)] p-5'>
+      <form onSubmit={handleCompanyProfileSubmit} className='space-y-5'>
+        <FormSection
+          title='Identité visuelle'
+          description='Logo et nom figurant sur vos factures.'
+          icon={Building2}
+        >
           {renderLogoDropzone()}
-        </div>
-
-        <div className='space-y-4'>
-          <div className='flex flex-col gap-2'>
-            <label className='label'>Nom de l’entreprise</label>
-            <input
-              name='company'
-              value={companyForm.company}
-              onChange={handleCompanyChange}
-              placeholder='Ex. Gocongo'
-              className='input'
-              required
-            />
-          </div>
-
           <div className='grid gap-4 sm:grid-cols-2'>
             <div className='flex flex-col gap-2'>
-              <label className='label'>Responsable</label>
+              <label className='label'>Nom de l’entreprise</label>
               <input
-                name='manager_name'
-                value={companyForm.manager_name}
+                name='company'
+                value={companyForm.company}
                 onChange={handleCompanyChange}
-                placeholder='Nom du gestionnaire'
+                placeholder='Ex. Gocongo'
                 className='input'
+                required
               />
             </div>
             <div className='flex flex-col gap-2'>
@@ -722,7 +725,69 @@ const Login = () => {
               />
             </div>
           </div>
+        </FormSection>
 
+        <FormSection title='Coordonnées principales'>
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Responsable</label>
+              <input
+                name='manager_name'
+                value={companyForm.manager_name}
+                onChange={handleCompanyChange}
+                placeholder='Nom du gestionnaire'
+                className='input'
+              />
+            </div>
+            <div className='flex flex-col gap-2'>
+              <label className='label'>Téléphone</label>
+              <input
+                name='phone'
+                value={companyForm.phone}
+                onChange={handleCompanyChange}
+                placeholder='+243 000 000 000'
+                className='input'
+              />
+            </div>
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='label'>Site web (optionnel)</label>
+            <input
+              name='website'
+              value={companyForm.website}
+              onChange={handleCompanyChange}
+              placeholder='https://kadi.app'
+              className='input'
+            />
+          </div>
+        </FormSection>
+
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <button type='button' onClick={() => setView(Steps.ACCOUNT)} className='btn-ghost justify-center'>
+            <ArrowLeft className='mr-2 h-4 w-4' />
+            Retour
+          </button>
+          <button type='submit' className='btn-primary justify-center'>
+            Étape suivante
+          </button>
+        </div>
+      </form>
+    </>
+  )
+
+  const renderCompanyDetailsStep = () => (
+    <>
+      <RegistrationStepper currentStep={Steps.COMPANY_DETAILS} steps={REGISTRATION_STEPS} />
+      <div className='mb-6 space-y-2'>
+        <p className='text-xs uppercase tracking-[0.25em] text-[var(--text-muted)]'>Étape 3/3</p>
+        <h1 className='text-2xl font-semibold text-[var(--text-dark)]'>Coordonnées & mentions légales</h1>
+        <p className='text-sm text-[var(--text-muted)]'>
+          Ces informations enrichissent vos factures. Vous pourrez les modifier à tout moment depuis l’onglet “Mon entreprise”.
+        </p>
+      </div>
+
+      <form onSubmit={handleRegistrationSubmit} className='space-y-5'>
+        <FormSection title='Adresse professionnelle'>
           <div className='flex flex-col gap-2'>
             <label className='label'>Adresse</label>
             <textarea
@@ -733,7 +798,6 @@ const Login = () => {
               className='textarea min-h-[100px]'
             />
           </div>
-
           <div className='grid gap-4 sm:grid-cols-2'>
             <div className='flex flex-col gap-2'>
               <label className='label'>Ville</label>
@@ -756,20 +820,22 @@ const Login = () => {
               />
             </div>
           </div>
+        </FormSection>
 
+        <FormSection title='Mentions légales (optionnel)'>
           <div className='grid gap-4 sm:grid-cols-2'>
             <div className='flex flex-col gap-2'>
-              <label className='label'>ID. Nat. (optionnel)</label>
+              <label className='label'>ID. Nat.</label>
               <input
                 name='national_id'
                 value={companyForm.national_id}
                 onChange={handleCompanyChange}
-                placeholder='ID nat. de l’entreprise'
+                placeholder='ID national de l’entreprise'
                 className='input'
               />
             </div>
             <div className='flex flex-col gap-2'>
-              <label className='label'>RCCM (optionnel)</label>
+              <label className='label'>RCCM</label>
               <input
                 name='rccm'
                 value={companyForm.rccm}
@@ -778,34 +844,25 @@ const Login = () => {
                 className='input'
               />
             </div>
+            <div className='flex flex-col gap-2 sm:col-span-2 md:sm:col-span-1'>
+              <label className='label'>NIF</label>
+              <input
+                name='nif'
+                value={companyForm.nif}
+                onChange={handleCompanyChange}
+                placeholder='Numéro d’impôt'
+                className='input'
+              />
+            </div>
           </div>
+        </FormSection>
 
-          <div className='flex flex-col gap-2 sm:w-1/2'>
-            <label className='label'>NIF (optionnel)</label>
-            <input
-              name='nif'
-              value={companyForm.nif}
-              onChange={handleCompanyChange}
-              placeholder='Numéro d’impôt'
-              className='input'
-            />
-          </div>
-        </div>
-
-        <div className='mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
-          <button
-            type='button'
-            onClick={() => setView(Steps.ACCOUNT)}
-            className='btn-ghost justify-center'
-          >
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <button type='button' onClick={() => setView(Steps.COMPANY_PROFILE)} className='btn-ghost justify-center'>
             <ArrowLeft className='mr-2 h-4 w-4' />
             Retour
           </button>
-          <button
-            type='submit'
-            className='btn-primary justify-center'
-            disabled={isRegisterSubmitting}
-          >
+          <button type='submit' className='btn-primary justify-center' disabled={isRegisterSubmitting}>
             {isRegisterSubmitting ? (
               <>
                 <Loader2 className='mr-2 h-4 w-4 animate-spin' /> Création du compte…
@@ -881,7 +938,8 @@ const Login = () => {
       <div className='mx-auto w-full max-w-[620px] rounded-[var(--radius-2xl)] border border-white/55 bg-[rgba(255,255,255,0.9)] px-9 py-10 shadow-[0_35px_120px_-42px_rgba(28,28,30,0.42)] backdrop-blur-xl'>
         {view === Steps.LOGIN && renderLoginForm()}
         {view === Steps.ACCOUNT && renderAccountStep()}
-        {view === Steps.COMPANY && renderCompanyStep()}
+        {view === Steps.COMPANY_PROFILE && renderCompanyProfileStep()}
+        {view === Steps.COMPANY_DETAILS && renderCompanyDetailsStep()}
         {view === Steps.SUCCESS && renderSuccessStep()}
       </div>
     </div>


### PR DESCRIPTION
- backend/controllers/authController.js: accept phone/website profile fields and ensure email confirmations fall back to Supabase resend when SMTP is absent; surface any issues via the API response
- frontend: split signup into three guided stages with sectioned forms, support new profile fields, and adjust post-signup messaging; overhaul company, clients, and catalogue forms using a shared FormSection component for a cleaner layout
- add FormSection component, clsx dependency, and update hooks to carry the new profile attributes